### PR TITLE
feat: Require tabulator instead of messytables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,12 +234,12 @@ Configuration:
     # The maximum size of files to load into DataStore. In bytes. Default is 1 GB.
     ckanext.xloader.max_content_length = 1000000000
 
-    # To always use messytables to load data, instead of attempting a direct
-    # PostgreSQL COPY, set this to True. This more closely matches the
+    # To always use the tabulator library to load data, instead of attempting a
+    # direct PostgreSQL COPY, set this to True. This more closely matches the
     # DataPusher's behavior. It has the advantage that the column types
     # are guessed. However it is more error prone, far slower and you can't run
     # the CPU-intensive queue on a separate machine.
-    ckanext.xloader.just_load_with_messytables = False
+    ckanext.xloader.just_load_with_tabulator = False
 
     # The maximum time for the loading of a resource before it is aborted.
     # Give an amount in seconds. Default is 60 minutes
@@ -301,8 +301,8 @@ To upgrade from DataPusher to XLoader:
    ``ckan.plugins`` line replace ``datapusher`` with ``xloader``.
 
 4. (Optional) If you wish, you can disable the direct loading and continue to
-   just use messytables - for more about this see the docs on config option:
-   ``ckanext.xloader.just_load_with_messytables``
+   just use tabulator - for more about this see the docs on config option:
+   ``ckanext.xloader.just_load_with_tabulator``
 
 5. Stop the datapusher worker::
 

--- a/README.rst
+++ b/README.rst
@@ -247,6 +247,21 @@ Configuration:
     # Deprecated: use ckanext.xloader.use_type_guessing instead.
     ckanext.xloader.just_load_with_messytables = False
 
+    # Whether ambiguous dates should be parsed day first. Defaults to False.
+    # If set to True, dates like '01.02.2022' will be parsed as day = 01,
+    # month = 02.
+    # NB: isoformat dates like '2022-01-02' will be parsed as YYYY-MM-DD, and
+    # this option will not override that.
+    # See https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.parse
+    # for more details.
+    ckanext.xloader.parse_dates_dayfirst = False
+
+    # Whether ambiguous dates should be parsed year first. Defaults to False.
+    # If set to True, dates like '01.02.03' will be parsed as year = 2001,
+    # month = 02, day = 03. See https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.parse
+    # for more details.
+    ckanext.xloader.parse_dates_yearfirst = False
+
     # The maximum time for the loading of a resource before it is aborted.
     # Give an amount in seconds. Default is 60 minutes
     ckanext.xloader.job_timeout = 3600

--- a/README.rst
+++ b/README.rst
@@ -244,6 +244,9 @@ Configuration:
     # this option to True.
     ckanext.xloader.use_type_guessing = False
 
+    # Deprecated: use ckanext.xloader.use_type_guessing instead.
+    ckanext.xloader.just_load_with_messytables = False
+
     # The maximum time for the loading of a resource before it is aborted.
     # Give an amount in seconds. Default is 60 minutes
     ckanext.xloader.job_timeout = 3600

--- a/README.rst
+++ b/README.rst
@@ -234,12 +234,15 @@ Configuration:
     # The maximum size of files to load into DataStore. In bytes. Default is 1 GB.
     ckanext.xloader.max_content_length = 1000000000
 
-    # To always use the tabulator library to load data, instead of attempting a
-    # direct PostgreSQL COPY, set this to True. This more closely matches the
-    # DataPusher's behavior. It has the advantage that the column types
+    # By default, xloader will first try to add tabular data to the DataStore
+    # with a direct PostgreSQL COPY. This is relatively fast, but does not
+    # guess column types. If this fails, xloader falls back to a method more
+    # like DataPusher's behaviour. This has the advantage that the column types
     # are guessed. However it is more error prone, far slower and you can't run
     # the CPU-intensive queue on a separate machine.
-    ckanext.xloader.just_load_with_tabulator = False
+    # To always skip the direct PostgreSQL COPY and use type guessing, set
+    # this option to True.
+    ckanext.xloader.use_type_guessing = False
 
     # The maximum time for the loading of a resource before it is aborted.
     # Give an amount in seconds. Default is 60 minutes
@@ -302,7 +305,7 @@ To upgrade from DataPusher to XLoader:
 
 4. (Optional) If you wish, you can disable the direct loading and continue to
    just use tabulator - for more about this see the docs on config option:
-   ``ckanext.xloader.just_load_with_tabulator``
+   ``ckanext.xloader.use_type_guessing``
 
 5. Stop the datapusher worker::
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -205,8 +205,11 @@ def xloader_data_into_datastore_(input, job_dict):
 
     # Load it
     logger.info('Loading CSV')
+    # If ckanext.xloader.use_type_guessing is not configured, fall back to
+    # deprecated ckanext.xloader.just_load_with_messytables
     use_type_guessing = asbool(config.get(
-        'ckanext.xloader.use_type_guessing', False))
+        'ckanext.xloader.use_type_guessing', config.get(
+            'ckanext.xloader.just_load_with_messytables', False)))
     logger.info("'use_type_guessing' mode is: %s",
                 use_type_guessing)
     try:

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -205,12 +205,12 @@ def xloader_data_into_datastore_(input, job_dict):
 
     # Load it
     logger.info('Loading CSV')
-    just_load_with_tabulator = asbool(config.get(
-        'ckanext.xloader.just_load_with_tabulator', False))
-    logger.info("'Just load with tabulator' mode is: %s",
-                just_load_with_tabulator)
+    use_type_guessing = asbool(config.get(
+        'ckanext.xloader.use_type_guessing', False))
+    logger.info("'use_type_guessing' mode is: %s",
+                use_type_guessing)
     try:
-        if just_load_with_tabulator:
+        if use_type_guessing:
             tabulator_load()
         else:
             try:

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -186,39 +186,39 @@ def xloader_data_into_datastore_(input, job_dict):
                         patch_only=True)
         logger.info('File Hash updated for resource: %s', resource['hash'])
 
-    def messytables_load():
+    def tabulator_load():
         try:
             loader.load_table(tmp_file.name,
                               resource_id=resource['id'],
                               mimetype=resource.get('format'),
                               logger=logger)
         except JobError as e:
-            logger.error('Error during messytables load: %s', e)
+            logger.error('Error during tabulator load: %s', e)
             raise
         loader.calculate_record_count(
             resource_id=resource['id'], logger=logger)
         set_datastore_active(data, resource, logger)
-        logger.info('Finished loading with messytables')
+        logger.info('Finished loading with tabulator')
         update_resource(resource={'id': resource['id'], 'hash': resource['hash']},
                         patch_only=True)
         logger.info('File Hash updated for resource: %s', resource['hash'])
 
     # Load it
     logger.info('Loading CSV')
-    just_load_with_messytables = asbool(config.get(
-        'ckanext.xloader.just_load_with_messytables', False))
-    logger.info("'Just load with messytables' mode is: %s",
-                just_load_with_messytables)
+    just_load_with_tabulator = asbool(config.get(
+        'ckanext.xloader.just_load_with_tabulator', False))
+    logger.info("'Just load with tabulator' mode is: %s",
+                just_load_with_tabulator)
     try:
-        if just_load_with_messytables:
-            messytables_load()
+        if just_load_with_tabulator:
+            tabulator_load()
         else:
             try:
                 direct_load()
             except JobError as e:
                 logger.warning('Load using COPY failed: %s', e)
-                logger.info('Trying again with messytables')
-                messytables_load()
+                logger.info('Trying again with tabulator')
+                tabulator_load()
     except FileCouldNotBeLoadedError as e:
         logger.warning('Loading excerpt for this format not supported.')
         logger.error('Loading file raised an error: %s', e)

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -342,7 +342,6 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
         raise LoaderError('No entries found - nothing to load')
 
 
-#
 _TYPE_MAPPING = {
     "<type 'unicode'>": 'text',
     "<type 'bool'>": 'text',

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -84,7 +84,8 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
     f_write = tempfile.NamedTemporaryFile(suffix=extension, delete=False)
     try:
         with Stream(csv_filepath, format=extension, skip_rows=skip_rows) as stream:
-            stream.save(target=f_write.name, format='csv', encoding='utf-8')
+            stream.save(target=f_write.name, format='csv', encoding='utf-8',
+                        delimiter=delimiter)
             csv_filepath = f_write.name
 
         # datastore db connection

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -15,6 +15,7 @@ from unidecode import unidecode
 
 import ckan.plugins as p
 from .job_exceptions import LoaderError, FileCouldNotBeLoadedError
+from .utils import headers_guess
 import ckan.plugins.toolkit as tk
 try:
     from ckan.plugins.toolkit import config
@@ -59,7 +60,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
             raise LoaderError('Could not detect tabular data in this file')
         row_set = table_set.tables.pop()
         try:
-            header_offset, headers = messytables.headers_guess(row_set.sample)
+            header_offset, headers = headers_guess(row_set.sample)
         except messytables.ReadError as e:
             raise LoaderError('Messytables error: {}'.format(e))
     # Some headers might have been converted from strings to floats and such.
@@ -254,7 +255,7 @@ def create_column_indexes(fields, resource_id, logger):
 
 
 def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
-    '''Loads an Excel file (or other tabular data recognized by messytables)
+    '''Loads an Excel file (or other tabular data recognized by tabulator)
     into Datastore and creates indexes.
 
     Largely copied from datapusher - see below. Is slower than load_csv.
@@ -283,7 +284,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
         if not table_set.tables:
             raise LoaderError('Could not parse file as tabular data')
         row_set = table_set.tables.pop()
-        offset, headers = messytables.headers_guess(row_set.sample)
+        offset, headers = headers_guess(row_set.sample)
 
         existing = datastore_resource_exists(resource_id)
         existing_info = None

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -55,7 +55,11 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
         with Stream(csv_filepath, format=extension) as stream:
             header_offset, headers = headers_guess(stream.sample)
     except TabulatorException as e:
-        raise LoaderError('Tabulator error: {}'.format(e))
+        try:
+            with Stream(csv_filepath, format=extension) as stream:
+                header_offset, headers = headers_guess(stream.sample)
+        except TabulatorException as e:
+            raise LoaderError('Tabulator error: {}'.format(e))
     except Exception as e:
         raise FileCouldNotBeLoadedError(e)
 
@@ -254,12 +258,14 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
                     custom_parsers={'csv': XloaderCSVParser}) as stream:
             header_offset, headers = headers_guess(stream.sample)
     except TabulatorException as e:
-        raise LoaderError('Tabulator error: {}'.format(e))
+        try:
+            with Stream(table_filepath, format=mimetype,
+                        custom_parsers={'csv': XloaderCSVParser}) as stream:
+                header_offset, headers = headers_guess(stream.sample)
+        except TabulatorException as e:
+            raise LoaderError('Tabulator error: {}'.format(e))
     except Exception as e:
         raise FileCouldNotBeLoadedError(e)
-
-    # Some headers might have been converted from strings to floats and such.
-    headers = encode_headers(headers)
 
     existing = datastore_resource_exists(resource_id)
     existing_info = None

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -12,6 +12,7 @@ import itertools
 from six.moves import zip
 import psycopg2
 import messytables
+from decimal import Decimal
 from tabulator import Stream, TabulatorException
 from unidecode import unidecode
 
@@ -345,12 +346,13 @@ _TYPE_MAPPING = {
     "<type 'bool'>": 'text',
     "<type 'int'>": 'numeric',
     "<type 'float'>": 'numeric',
+    "<class 'decimal.Decimal'>": 'numeric',
     "<type 'datetime.datetime'>": 'timestamp'
 }
 
 
 def get_types():
-    _TYPES = [int, bool, str, datetime.datetime, float]
+    _TYPES = [int, bool, str, datetime.datetime, float, Decimal]
     TYPE_MAPPING = config.get('TYPE_MAPPING', _TYPE_MAPPING)
     return _TYPES, TYPE_MAPPING
 

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -348,7 +348,7 @@ _TYPE_MAPPING = {
 
 
 def get_types():
-    _TYPES = [str, float, int, datetime.datetime]
+    _TYPES = [int, bool, str, datetime.datetime, float]
     TYPE_MAPPING = config.get('TYPE_MAPPING', _TYPE_MAPPING)
     return _TYPES, TYPE_MAPPING
 

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -17,6 +17,7 @@ from unidecode import unidecode
 
 import ckan.plugins as p
 from .job_exceptions import LoaderError, FileCouldNotBeLoadedError
+from .parser import XloaderCSVParser
 from .utils import headers_guess, type_guess
 import ckan.plugins.toolkit as tk
 try:
@@ -247,7 +248,8 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
     logger.info('Determining column names and types')
     extension = os.path.splitext(table_filepath)[1].strip('.')
     try:
-        with Stream(table_filepath, format=extension) as stream:
+        print(extension)
+        with Stream(table_filepath, format=extension, custom_parsers={'csv': XloaderCSVParser}) as stream:
             header_offset, headers = headers_guess(stream.sample)
     except TabulatorException as e:
         raise LoaderError('Tabulator error: {}'.format(e))
@@ -286,7 +288,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
 
     headers = [header.strip()[:MAX_COLUMN_LENGTH] for header in headers if header.strip()]
 
-    with Stream(table_filepath, format=extension, skip_rows=skip_rows) as stream:
+    with Stream(table_filepath, format=extension, skip_rows=skip_rows, custom_parsers={'csv': XloaderCSVParser}) as stream:
         def row_iterator():
             for row in stream:
                 data_row = {}

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -349,6 +349,10 @@ _TYPE_MAPPING = {
     "<type 'float'>": 'numeric',
     "<class 'decimal.Decimal'>": 'numeric',
     "<type 'datetime.datetime'>": 'timestamp',  # Python 2
+    "<class 'str'>": 'text',
+    "<class 'bool'>": 'text',
+    "<class 'int'>": 'numeric',
+    "<class 'float'>": 'numeric',
     "<class 'datetime.datetime'>": 'timestamp',  # Python 3
 }
 

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -58,6 +58,10 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
     # Some headers might have been converted from strings to floats and such.
     headers = encode_headers(headers)
 
+    # Get the list of rows to skip. The rows in the tabulator stream are
+    # numbered starting with 1.
+    skip_rows = list(range(1, header_offset + 1))
+
     # Get the delimiter used in the file
     delimiter = stream.dialect.get('delimiter')
     if delimiter is None:
@@ -75,10 +79,8 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
     logger.info('Ensuring character coding is UTF8')
     f_write = tempfile.NamedTemporaryFile(suffix=extension, delete=False)
     try:
-        with open(csv_filepath, 'rb') as f_read:
-            csv_decoder = CSVWriter(delimiter=delimiter)
-            csv_decoder.write(source=f_read, target=f_write.name, headers=headers,
-                              encoding='utf-8')
+        with Stream(csv_filepath, format=extension, skip_rows=skip_rows) as stream:
+            stream.save(target=f_write.name, format='csv', encoding='utf-8')
             csv_filepath = f_write.name
 
         # datastore db connection

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -2,25 +2,25 @@
 from __future__ import absolute_import
 
 import datetime
-import decimal
-
-from six import text_type as str
+import itertools
 import os
 import os.path
 import tempfile
-import itertools
-
-from six.moves import zip
-import psycopg2
 from decimal import Decimal
+
+import psycopg2
+from six import text_type as str
+from six.moves import zip
 from tabulator import Stream, TabulatorException
 from unidecode import unidecode
 
 import ckan.plugins as p
-from .job_exceptions import LoaderError, FileCouldNotBeLoadedError
+import ckan.plugins.toolkit as tk
+
+from .job_exceptions import FileCouldNotBeLoadedError, LoaderError
 from .parser import XloaderCSVParser
 from .utils import headers_guess, type_guess
-import ckan.plugins.toolkit as tk
+
 try:
     from ckan.plugins.toolkit import config
 except ImportError:
@@ -289,7 +289,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
         types = [
             {
                 'text': str,
-                'numeric': decimal.Decimal,
+                'numeric': Decimal,
                 'timestamp': datetime.datetime,
             }.get(existing_info.get(h, {}).get('type_override'), t)
             for t, h in zip(types, headers)]

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -342,13 +342,15 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
         raise LoaderError('No entries found - nothing to load')
 
 
+#
 _TYPE_MAPPING = {
     "<type 'unicode'>": 'text',
     "<type 'bool'>": 'text',
     "<type 'int'>": 'numeric',
     "<type 'float'>": 'numeric',
     "<class 'decimal.Decimal'>": 'numeric',
-    "<type 'datetime.datetime'>": 'timestamp'
+    "<type 'datetime.datetime'>": 'timestamp',  # Python 2
+    "<class 'datetime.datetime'>": 'timestamp',  # Python 3
 }
 
 

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import datetime
+import decimal
 
 from six import text_type as str
 import os
@@ -11,7 +12,6 @@ import itertools
 
 from six.moves import zip
 import psycopg2
-import messytables
 from decimal import Decimal
 from tabulator import Stream, TabulatorException
 from unidecode import unidecode
@@ -282,9 +282,9 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
     if existing_info:
         types = [
             {
-                'text': messytables.StringType(),
-                'numeric': messytables.DecimalType(),
-                'timestamp': messytables.DateUtilType(),
+                'text': str,
+                'numeric': decimal.Decimal,
+                'timestamp': datetime.datetime,
             }.get(existing_info.get(h, {}).get('type_override'), t)
             for t, h in zip(types, headers)]
 

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -46,7 +46,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
     '''Loads a CSV into DataStore. Does not create the indexes.'''
 
     # Determine the header row
-    extension = os.path.splitext(csv_filepath)[1]
+    extension = os.path.splitext(csv_filepath)[1].strip('.')
     try:
         with Stream(csv_filepath, format=extension) as stream:
             header_offset, headers = headers_guess(stream.sample)

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -113,7 +113,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
         fields = [
             {'id': header_name,
              'type': existing_info.get(header_name, {})
-             .get('type_override') or 'text',
+                .get('type_override') or 'text',
              }
             for header_name in headers]
 
@@ -250,8 +250,8 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
     logger.info('Determining column names and types')
     extension = os.path.splitext(table_filepath)[1].strip('.')
     try:
-        print(extension)
-        with Stream(table_filepath, format=extension, custom_parsers={'csv': XloaderCSVParser}) as stream:
+        with Stream(table_filepath, format=extension,
+                    custom_parsers={'csv': XloaderCSVParser}) as stream:
             header_offset, headers = headers_guess(stream.sample)
     except TabulatorException as e:
         raise LoaderError('Tabulator error: {}'.format(e))
@@ -290,12 +290,12 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
 
     headers = [header.strip()[:MAX_COLUMN_LENGTH] for header in headers if header.strip()]
 
-    with Stream(table_filepath, format=extension, skip_rows=skip_rows, custom_parsers={'csv': XloaderCSVParser}) as stream:
+    with Stream(table_filepath, format=extension, skip_rows=skip_rows,
+                custom_parsers={'csv': XloaderCSVParser}) as stream:
         def row_iterator():
             for row in stream:
                 data_row = {}
                 for index, cell in enumerate(row):
-                    # TODO: cast to required types
                     data_row[headers[index]] = cell
                 yield data_row
         result = row_iterator()

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -65,13 +65,6 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
         logger.warning('Could not determine delimiter from file, use default ","')
         delimiter = ','
 
-    # Setup the converters that run when you iterate over the row_set.
-    # With pgloader only the headers will be iterated over.
-    row_set.register_processor(messytables.headers_processor(headers))
-    row_set.register_processor(
-        messytables.offset_processor(header_offset + 1))
-    # types = messytables.type_guess(row_set.sample, types=TYPES, strict=True)
-
     headers = [header.strip()[:MAX_COLUMN_LENGTH] for header in headers if header.strip()]
 
     # TODO worry about csv header name problems

--- a/ckanext/xloader/parser.py
+++ b/ckanext/xloader/parser.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+import csv
+import six
+
+from codecs import iterencode
+from dateutil.parser import parser, ParserError
+from decimal import Decimal, InvalidOperation
+from itertools import chain
+from tabulator import helpers
+from tabulator.parser import Parser
+
+CSV_SAMPLE_LINES = 100
+
+
+class XloaderCSVParser(Parser):
+    """Extends tabulator CSVParser to detect datetime and numeric values.
+    """
+
+    # Public
+
+    options = [
+        'delimiter',
+        'doublequote',
+        'escapechar',
+        'quotechar',
+        'quoting',
+        'skipinitialspace',
+        'lineterminator'
+    ]
+
+    def __init__(self, loader, force_parse=False, **options):
+        super(XloaderCSVParser, self).__init__(loader, force_parse, **options)
+
+        # Make bytes
+        if six.PY2:
+            for key, value in options.items():
+                if isinstance(value, six.string_types):
+                    options[key] = str(value)
+
+        # Set attributes
+        self.__loader = loader
+        self.__options = options
+        self.__force_parse = force_parse
+        self.__extended_rows = None
+        self.__encoding = None
+        self.__dialect = None
+        self.__chars = None
+
+    @property
+    def closed(self):
+        return self.__chars is None or self.__chars.closed
+
+    def open(self, source, encoding=None):
+        self.close()
+        self.__chars = self.__loader.load(source, encoding=encoding)
+        self.__encoding = getattr(self.__chars, 'encoding', encoding)
+        if self.__encoding:
+            self.__encoding.lower()
+        self.reset()
+
+    def close(self):
+        if not self.closed:
+            self.__chars.close()
+
+    def reset(self):
+        helpers.reset_stream(self.__chars)
+        self.__extended_rows = self.__iter_extended_rows()
+
+    @property
+    def encoding(self):
+        return self.__encoding
+
+    @property
+    def dialect(self):
+        if self.__dialect:
+            dialect = {
+                'delimiter': self.__dialect.delimiter,
+                'doubleQuote': self.__dialect.doublequote,
+                'lineTerminator': self.__dialect.lineterminator,
+                'quoteChar': self.__dialect.quotechar,
+                'skipInitialSpace': self.__dialect.skipinitialspace,
+            }
+            if self.__dialect.escapechar is not None:
+                dialect['escapeChar'] = self.__dialect.escapechar
+            return dialect
+
+    @property
+    def extended_rows(self):
+        return self.__extended_rows
+
+    # Private
+
+    def __iter_extended_rows(self):
+
+        def type_value(value):
+            """Returns numeric values as Decimal(). Uses dateutil to parse
+            date values. Otherwise, returns values as it receives them
+            (strings).
+            """
+            if value in ('', None):
+                return ''
+
+            try:
+                return Decimal(value)
+            except InvalidOperation:
+                pass
+
+            try:
+                p = parser()
+                return p.parse(value)
+            except ParserError:
+                pass
+
+            return value
+
+        # For PY2 encode/decode
+        if six.PY2:
+            # Reader requires utf-8 encoded stream
+            bytes = iterencode(self.__chars, 'utf-8')
+            sample, dialect = self.__prepare_dialect(bytes)
+            items = csv.reader(chain(sample, bytes), dialect=dialect)
+            for row_number, item in enumerate(items, start=1):
+                values = []
+                for value in item:
+                    value = value.decode('utf-8')
+                    value = type_value(value)
+                    values.append(value)
+                yield row_number, None, list(values)
+
+        # For PY3 use chars
+        else:
+            sample, dialect = self.__prepare_dialect(self.__chars)
+            items = csv.reader(chain(sample, self.__chars), dialect=dialect)
+            for row_number, item in enumerate(items, start=1):
+                values = []
+                for value in item:
+                    value = type_value(value)
+                    values.append(value)
+                yield row_number, None, list(values)
+
+    def __prepare_dialect(self, stream):
+
+        # Get sample
+        sample = []
+        while True:
+            try:
+                sample.append(next(stream))
+            except StopIteration:
+                break
+            if len(sample) >= CSV_SAMPLE_LINES:
+                break
+
+        # Get dialect
+        try:
+            separator = b'' if six.PY2 else ''
+            delimiter = self.__options.get('delimiter', ',\t;|')
+            dialect = csv.Sniffer().sniff(separator.join(sample), delimiter)
+            if not dialect.escapechar:
+                dialect.doublequote = True
+        except csv.Error:
+            class dialect(csv.excel):
+                pass
+        for key, value in self.__options.items():
+            setattr(dialect, key, value)
+        # https://github.com/frictionlessdata/FrictionlessDarwinCore/issues/1
+        if getattr(dialect, 'quotechar', None) == '':
+            setattr(dialect, 'quoting', csv.QUOTE_NONE)
+
+        self.__dialect = dialect
+        return sample, dialect

--- a/ckanext/xloader/parser.py
+++ b/ckanext/xloader/parser.py
@@ -5,9 +5,16 @@ from decimal import Decimal, InvalidOperation
 from itertools import chain
 
 import six
-from dateutil.parser import ParserError, parser
+from ckan.plugins.toolkit import asbool
+from dateutil.parser import isoparser, ParserError, parser
 from tabulator import helpers
 from tabulator.parser import Parser
+
+try:
+    from ckan.plugins.toolkit import config
+except ImportError:
+    # older versions of ckan
+    from pylons import config
 
 CSV_SAMPLE_LINES = 100
 
@@ -107,8 +114,18 @@ class XloaderCSVParser(Parser):
                 pass
 
             try:
+                i = isoparser()
+                return i.isoparse(value)
+            except ValueError:
+                pass
+
+            try:
                 p = parser()
-                return p.parse(value)
+                yearfirst = asbool(config.get(
+                    'ckanext.xloader.parse_dates_yearfirst', False))
+                dayfirst = asbool(config.get(
+                    'ckanext.xloader.parse_dates_dayfirst', False))
+                return p.parse(value, yearfirst=yearfirst, dayfirst=dayfirst)
             except ParserError:
                 pass
 

--- a/ckanext/xloader/parser.py
+++ b/ckanext/xloader/parser.py
@@ -35,7 +35,7 @@ class XloaderCSVParser(Parser):
         if six.PY2:
             for key, value in options.items():
                 if isinstance(value, six.string_types):
-                    options[key] = str(value)
+                    options[key] = six.text_type(value)
 
         # Set attributes
         self.__loader = loader

--- a/ckanext/xloader/parser.py
+++ b/ckanext/xloader/parser.py
@@ -51,6 +51,7 @@ class XloaderCSVParser(Parser):
         return self.__chars is None or self.__chars.closed
 
     def open(self, source, encoding=None):
+        # Close the character stream, if necessary, before reloading it.
         self.close()
         self.__chars = self.__loader.load(source, encoding=encoding)
         self.__encoding = getattr(self.__chars, 'encoding', encoding)

--- a/ckanext/xloader/parser.py
+++ b/ckanext/xloader/parser.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 import csv
-import six
-
 from codecs import iterencode
-from dateutil.parser import parser, ParserError
 from decimal import Decimal, InvalidOperation
 from itertools import chain
+
+import six
+from dateutil.parser import ParserError, parser
 from tabulator import helpers
 from tabulator.parser import Parser
 

--- a/ckanext/xloader/tests/samples/date_formats.csv
+++ b/ckanext/xloader/tests/samples/date_formats.csv
@@ -1,0 +1,5 @@
+date,temperature,place
+2011-01-02,-1,Galway
+01-03-2011,0.5,Galway
+2011.01.02,5,Berkeley
+11-01-03,6,Berkeley

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -428,9 +428,9 @@ class TestxloaderDataIntoDatastore(object):
 
     @mock_actions
     @responses.activate
-    def test_messytables(self):
+    def test_tabulator(self):
         # xloader's COPY can't handle xls, so it will be dealt with by
-        # messytables
+        # tabulator
         self.register_urls(
             filename="simple.xls", content_type="application/vnd.ms-excel"
         )
@@ -515,7 +515,7 @@ class TestxloaderDataIntoDatastore(object):
 
         # check messytable portion of the logs
         logs = Logs(logs[copy_error_index + 1:])
-        assert logs[0] == (u"INFO", u"Trying again with messytables")
+        assert logs[0] == (u"INFO", u"Trying again with tabulator")
         logs.assert_no_errors()
 
         # Check ANALYZE was run
@@ -529,7 +529,7 @@ class TestxloaderDataIntoDatastore(object):
         # This csv has an extra comma which causes the COPY to throw a
         # psycopg2.DataError and the umlaut can cause problems for logging the
         # error. We need to check that it correctly reverts to using
-        # messytables to load it
+        # tabulator to load it
         data = {
             "api_key": self.api_key,
             "job_type": "xloader_to_datastore",
@@ -583,7 +583,7 @@ class TestxloaderDataIntoDatastore(object):
         # 'invalid byte sequence for encoding "UTF8": 0x00' which causes
         # the COPY to throw a psycopg2.DataError and umlauts in the file can
         # cause problems for logging the error. We need to check that
-        # it correctly reverts to using messytables to load it
+        # it correctly reverts to using tabulator to load it
         data = {
             'api_key': self.api_key,
             'job_type': 'xloader_to_datastore',

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -777,11 +777,7 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 mimetype="text/csv",
                 logger=logger,
             )
-        assert "Error with field definition" in str(exception.value)
-        assert (
-            '"<?xml version="1.0" encoding="utf-8" ?>" is not a valid field name'
-            in str(exception.value)
-        )
+        assert "Tabulator error: Format \"kml\" is not supported" in str(exception.value)
 
     def test_geojson(self):
         filepath = get_sample_filepath("polling_locations.geojson")
@@ -794,11 +790,7 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 mimetype="text/csv",
                 logger=logger,
             )
-        assert "Error with field definition" in str(exception.value)
-        assert (
-            '"{"type":"FeatureCollection"" is not a valid field name'
-            in str(exception.value)
-        )
+        assert "Tabulator error: Format \"geojson\" is not supported" in str(exception.value)
 
     def test_shapefile_zip(self):
         filepath = get_sample_filepath("polling_locations.shapefile.zip")

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -611,23 +611,6 @@ class TestLoadCsv(TestLoadBase):
             u"tsvector",
         ] + [u"text"] * (len(records[0]) - 1)
 
-    def test_integer_header_xlsx(self):
-        # this xlsx file's header is detected by utils.headers_guess as
-        # integers and we should cope with that
-        csv_filepath = get_sample_filepath("go-realtime.xlsx")
-        resource_id = factories.Resource()["id"]
-        try:
-            loader.load_csv(
-                csv_filepath,
-                resource_id=resource_id,
-                mimetype="CSV",
-                logger=logger,
-            )
-        except (LoaderError, UnicodeDecodeError):
-            pass
-        else:
-            assert 0, "There should have been an exception"
-
     def test_reload(self, Session):
         csv_filepath = get_sample_filepath("simple.csv")
         resource_id = "test1"

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -788,7 +788,7 @@ class TestLoadUnhandledTypes(TestLoadBase):
             )
 
 
-class TestLoadMessytables(TestLoadBase):
+class TestLoadTabulator(TestLoadBase):
     def test_simple(self, Session):
         csv_filepath = get_sample_filepath("simple.xls")
         resource_id = "test1"

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -612,7 +612,7 @@ class TestLoadCsv(TestLoadBase):
         ] + [u"text"] * (len(records[0]) - 1)
 
     def test_integer_header_xlsx(self):
-        # this xlsx file's header is detected by messytables.headers_guess as
+        # this xlsx file's header is detected by utils.headers_guess as
         # integers and we should cope with that
         csv_filepath = get_sample_filepath("go-realtime.xlsx")
         resource_id = factories.Resource()["id"]

--- a/ckanext/xloader/tests/test_parser.py
+++ b/ckanext/xloader/tests/test_parser.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+import os
+import pytest
+
+from decimal import Decimal
+from datetime import datetime
+
+from tabulator import Stream
+from ckanext.xloader.parser import XloaderCSVParser
+
+csv_filepath = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "samples", "date_formats.csv")
+)
+
+
+class TestParser(object):
+    def test_simple(self):
+        with Stream(csv_filepath, format='csv',
+                    custom_parsers={'csv': XloaderCSVParser}) as stream:
+            assert stream.sample == [
+                [
+                    'date',
+                    'temperature',
+                    'place'
+                ],
+                [
+                    datetime(2011, 1, 2, 0, 0),
+                    Decimal('-1'),
+                    'Galway'
+                ],
+                [
+                    datetime(2011, 1, 3, 0, 0),
+                    Decimal('0.5'),
+                    'Galway'
+                ],
+                [
+                    datetime(2011, 1, 2, 0, 0),
+                    Decimal('5'),
+                    'Berkeley'
+                ],
+                [
+                    datetime(2003, 11, 1, 0, 0),
+                    Decimal('6'),
+                    'Berkeley'
+                ],
+            ]
+
+    @pytest.mark.ckan_config("ckanext.xloader.parse_dates_dayfirst", True)
+    def test_dayfirst(self):
+        print('test_dayfirst')
+        with Stream(csv_filepath, format='csv',
+                    custom_parsers={'csv': XloaderCSVParser}) as stream:
+            assert stream.sample == [
+                [
+                    'date',
+                    'temperature',
+                    'place'
+                ],
+                [
+                    datetime(2011, 1, 2, 0, 0),
+                    Decimal('-1'),
+                    'Galway'
+                ],
+                [
+                    datetime(2011, 3, 1, 0, 0),
+                    Decimal('0.5'),
+                    'Galway'
+                ],
+                [
+                    datetime(2011, 2, 1, 0, 0),
+                    Decimal('5'),
+                    'Berkeley'
+                ],
+                [
+                    datetime(2003, 1, 11, 0, 0),
+                    Decimal('6'),
+                    'Berkeley'
+                ],
+            ]
+
+    @pytest.mark.ckan_config("ckanext.xloader.parse_dates_yearfirst", True)
+    def test_yearfirst(self):
+        print('test_yearfirst')
+        with Stream(csv_filepath, format='csv',
+                    custom_parsers={'csv': XloaderCSVParser}) as stream:
+            assert stream.sample == [
+                [
+                    'date',
+                    'temperature',
+                    'place'
+                ],
+                [
+                    datetime(2011, 1, 2, 0, 0),
+                    Decimal('-1'),
+                    'Galway'
+                ],
+                [
+                    datetime(2011, 1, 3, 0, 0),
+                    Decimal('0.5'),
+                    'Galway'
+                ],
+                [
+                    datetime(2011, 1, 2, 0, 0),
+                    Decimal('5'),
+                    'Berkeley'
+                ],
+                [
+                    datetime(2011, 1, 3, 0, 0),
+                    Decimal('6'),
+                    'Berkeley'
+                ],
+            ]
+
+    @pytest.mark.ckan_config("ckanext.xloader.parse_dates_dayfirst", True)
+    @pytest.mark.ckan_config("ckanext.xloader.parse_dates_yearfirst", True)
+    def test_yearfirst_dayfirst(self):
+        with Stream(csv_filepath, format='csv',
+                    custom_parsers={'csv': XloaderCSVParser}) as stream:
+            assert stream.sample == [
+                [
+                    'date',
+                    'temperature',
+                    'place'
+                ],
+                [
+                    datetime(2011, 1, 2, 0, 0),
+                    Decimal('-1'),
+                    'Galway'
+                ],
+                [
+                    datetime(2011, 3, 1, 0, 0),
+                    Decimal('0.5'),
+                    'Galway'
+                ],
+                [
+                    datetime(2011, 2, 1, 0, 0),
+                    Decimal('5'),
+                    'Berkeley'
+                ],
+                [
+                    datetime(2011, 3, 1, 0, 0),
+                    Decimal('6'),
+                    'Berkeley'
+                ],
+            ]

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -70,7 +70,7 @@ def column_count_modal(rows):
     """
     counts = defaultdict(int)
     for row in rows:
-        length = len([c for c in row if not c.empty])
+        length = len([c for c in row if c != ''])
         if length > 1:
             counts[length] += 1
     if not len(counts):
@@ -91,10 +91,10 @@ def headers_guess(rows, tolerance=1):
     rows = list(rows)
     modal = column_count_modal(rows)
     for i, row in enumerate(rows):
-        length = len([c for c in row if not c.empty])
+        length = len([c for c in row if c != ''])
         if length >= modal - tolerance:
             # TODO: use type guessing to check that this row has
             # strings and does not conform to the type schema of
             # the table.
-            return i, [c.value for c in row]
+            return i, row
     return 0, []

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -1,5 +1,6 @@
 import datetime
 from collections import defaultdict
+from six import text_type as str
 
 import ckan.plugins as p
 

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import ckan.plugins as p
 
 
@@ -57,3 +59,42 @@ def get_xloader_user_apitoken():
 
     site_user = p.toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
     return site_user["apikey"]
+
+
+def column_count_modal(rows):
+    """ Return the modal value of columns in the row_set's
+    sample. This can be assumed to be the number of columns
+    of the table.
+
+    Copied from messytables.
+    """
+    counts = defaultdict(int)
+    for row in rows:
+        length = len([c for c in row if not c.empty])
+        if length > 1:
+            counts[length] += 1
+    if not len(counts):
+        return 0
+    return max(list(counts.items()), key=lambda k_v: k_v[1])[0]
+
+
+def headers_guess(rows, tolerance=1):
+    """ Guess the offset and names of the headers of the row set.
+    This will attempt to locate the first row within ``tolerance``
+    of the mode of the number of rows in the row set sample.
+
+    The return value is a tuple of the offset of the header row
+    and the names of the columns.
+
+    Copied from messytables.
+    """
+    rows = list(rows)
+    modal = column_count_modal(rows)
+    for i, row in enumerate(rows):
+        length = len([c for c in row if not c.empty])
+        if length >= modal - tolerance:
+            # TODO: use type guessing to check that this row has
+            # strings and does not conform to the type schema of
+            # the table.
+            return i, [c.value for c in row]
+    return 0, []

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -1,6 +1,7 @@
 import datetime
 from collections import defaultdict
 from decimal import Decimal
+
 from six import text_type as str
 
 import ckan.plugins as p

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -98,3 +98,66 @@ def headers_guess(rows, tolerance=1):
             # the table.
             return i, row
     return 0, []
+
+
+def type_guess(rows, types=TYPES, strict=False):
+    """ The type guesser aggregates the number of successful
+    conversions of each column to each type, weights them by a
+    fixed type priority and select the most probable type for
+    each column based on that figure. It returns a list of
+    ``CellType``. Empty cells are ignored.
+
+    Strict means that a type will not be guessed
+    if parsing fails for a single cell in the column."""
+    guesses = []
+    type_instances = [i for t in types for i in t.instances()]
+    if strict:
+        at_least_one_value = []
+        for ri, row in enumerate(rows):
+            diff = len(row) - len(guesses)
+            for _ in range(diff):
+                typesdict = {}
+                for type in type_instances:
+                    typesdict[type] = 0
+                guesses.append(typesdict)
+                at_least_one_value.append(False)
+            for ci, cell in enumerate(row):
+                if not cell.value:
+                    continue
+                at_least_one_value[ci] = True
+                for type in list(guesses[ci].keys()):
+                    if not type.test(cell.value):
+                        guesses[ci].pop(type)
+        # no need to set guessing weights before this
+        # because we only accept a type if it never fails
+        for i, guess in enumerate(guesses):
+            for type in guess:
+                guesses[i][type] = type.guessing_weight
+        # in case there were no values at all in the column,
+        # we just set the guessed type to string
+        for i, v in enumerate(at_least_one_value):
+            if not v:
+                guesses[i] = {StringType(): 0}
+    else:
+        for i, row in enumerate(rows):
+            diff = len(row) - len(guesses)
+            for _ in range(diff):
+                guesses.append(defaultdict(int))
+            for i, cell in enumerate(row):
+                # add string guess so that we have at least one guess
+                guesses[i][StringType()] = guesses[i].get(StringType(), 0)
+                if not cell.value:
+                    continue
+                for type in type_instances:
+                    if type.test(cell.value):
+                        guesses[i][type] += type.guessing_weight
+        _columns = []
+    _columns = []
+    for guess in guesses:
+        # this first creates an array of tuples because we want the types to be
+        # sorted. Even though it is not specified, python chooses the first
+        # element in case of a tie
+        # See: http://stackoverflow.com/a/6783101/214950
+        guesses_tuples = [(t, guess[t]) for t in type_instances if t in guess]
+        _columns.append(max(guesses_tuples, key=lambda t_n: t_n[1])[0])
+    return _columns

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -1,5 +1,6 @@
 import datetime
 from collections import defaultdict
+from decimal import Decimal
 from six import text_type as str
 
 import ckan.plugins as p
@@ -102,7 +103,7 @@ def headers_guess(rows, tolerance=1):
     return 0, []
 
 
-TYPES = [int, bool, str, datetime.datetime, float]
+TYPES = [int, bool, str, datetime.datetime, float, Decimal]
 
 
 def type_guess(rows, types=TYPES, strict=False):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 responses==0.10.9
 mock==2.0.0
+factory-boy==2.4
 flake8
 pytest-ckan
 pytest-cov

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 responses==0.10.9
 mock==2.0.0
-factory-boy==2.4
 flake8
 pytest-ckan
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ckantoolkit
+messytables==0.15.2
 requests[security]>=2.11.1
 six>=1.12.0
 tabulator==1.53.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ckantoolkit
-messytables==0.15.2
 requests[security]>=2.11.1
 six>=1.12.0
+tabulator==1.53.5
 Unidecode==1.0.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests[security]>=2.11.1
 six>=1.12.0
 tabulator==1.53.5
 Unidecode==1.0.22
+python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ckantoolkit
-messytables==0.15.2
 requests[security]>=2.11.1
 six>=1.12.0
 tabulator==1.53.5


### PR DESCRIPTION
This PR re-enables uploading XLSX files to the DataStore.

Previously, xloader used [messytables](https://github.com/okfn/messytables) to parse and upload tabular data, including guessing the data type of each column (string, int, etc.). Messytables used xlrd to load XLSX tables, but [this functionality was removed from xlrd version 1.2 and up](https://stackoverflow.com/a/65266497).

As messytables is now deprecated and superseded by [tabulator](https://github.com/frictionlessdata/tabulator-py), I decided to replace it with tabulator throughout ckanext-xloader. (Tabulator has actually also been superseded by [Frictionless Framework](https://github.com/frictionlessdata/frictionless-py), but it is still supported and available on PyPi. Frictionless Framework only supports Python 3, not Python 2, which is why I didn't use it here.)

Some features of messytables were not carried over into tabulator, so I have copied the relevant functions from messytables into [utils.py](https://github.com/opendata-swiss/ckanext-xloader/pull/7/files#diff-bbf8a49e221d6e09dbd6c31450ec5d5dc7c0c747254076f6448042a52ba3131b). I also added a custom [csv parser](ckanext/xloader/parser.py) that allows detection of datetime and numeric values.