### PR TITLE
fix: Use mimetype on second try loading the csv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,8 +238,7 @@ Configuration:
     # with a direct PostgreSQL COPY. This is relatively fast, but does not
     # guess column types. If this fails, xloader falls back to a method more
     # like DataPusher's behaviour. This has the advantage that the column types
-    # are guessed. However it is more error prone, far slower and you can't run
-    # the CPU-intensive queue on a separate machine.
+    # are guessed. However it is more error prone and far slower.
     # To always skip the direct PostgreSQL COPY and use type guessing, set
     # this option to True.
     ckanext.xloader.use_type_guessing = False

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import os
 import pytest
+import six
 import sqlalchemy.orm as orm
 import datetime
 import logging
@@ -783,7 +784,12 @@ class TestLoadUnhandledTypes(TestLoadBase):
             in str(exception.value)
         )
 
-    def test_shapefile_zip(self):
+    @pytest.mark.skipif(
+        six.PY3,
+        reason="In Python 3, tabulator will unzip archives and load the first "
+               "file found (if possible)."
+    )
+    def test_shapefile_zip_python2(self):
         filepath = get_sample_filepath("polling_locations.shapefile.zip")
         resource_id = "test1"
         factories.Resource(id=resource_id)
@@ -794,6 +800,32 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 mimetype="text/csv",
                 logger=logger,
             )
+
+    @pytest.mark.skipif(
+        six.PY2,
+        reason="In Python 2, tabulator will not load a zipped archive, so the "
+               "loader will raise a LoaderError."
+    )
+    def test_shapefile_zip_python3(self, Session):
+        # tabulator unzips the archive and tries to load the first file it
+        # finds, 'Polling_Locations.cpg'. This file only contains the
+        # following data: `UTF-8`.
+        filepath = get_sample_filepath("polling_locations.shapefile.zip")
+        resource_id = "test1"
+        factories.Resource(id=resource_id)
+        loader.load_csv(
+            filepath,
+            resource_id=resource_id,
+            mimetype="text/csv",
+            logger=logger,
+        )
+
+        assert self._get_records(Session, "test1") == []
+        assert self._get_column_names(Session, "test1") == [
+            '_id',
+            '_full_text',
+            'UTF-8'
+        ]
 
 
 class TestLoadTabulator(TestLoadBase):

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -760,7 +760,11 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 mimetype="text/csv",
                 logger=logger,
             )
-        assert "Tabulator error: Format \"kml\" is not supported" in str(exception.value)
+        assert "Error with field definition" in str(exception.value)
+        assert (
+            '"<?xml version="1.0" encoding="utf-8" ?>" is not a valid field name'
+            in str(exception.value)
+        )
 
     def test_geojson(self):
         filepath = get_sample_filepath("polling_locations.geojson")
@@ -773,7 +777,11 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 mimetype="text/csv",
                 logger=logger,
             )
-        assert "Tabulator error: Format \"geojson\" is not supported" in str(exception.value)
+        assert "Error with field definition" in str(exception.value)
+        assert (
+            '"{"type":"FeatureCollection"" is not a valid field name'
+            in str(exception.value)
+        )
 
     def test_shapefile_zip(self):
         filepath = get_sample_filepath("polling_locations.shapefile.zip")


### PR DESCRIPTION
Also, convert mimetype to lowercase before using it. The mimetype passed in here by the worker is the resource's format, which might not have been saved in all lower case.